### PR TITLE
feat: add more detail about what a threat model is

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -99,13 +99,7 @@ and \href{https://adore.software/}{ADORE.software}.
 
 \section*{Tip 1: Consider your threat model}
 
-When making plans, it's useful to know what you're planning \emph{for}.
-Being explicit about \textbf{threat models} helps you prioritize,
-build consensus with colleagues,
-and check whether you have forgotten something important.
-As with all disasters,
-making those plans before you need them helps reduce the odds of them being needed,
-as planning may help you identify risks you can eliminate.
+When making plans, it's useful to know what you're planning \emph{for}. Building a \textbf{threat model} means taking a structured approach to identifying sources of threats, considering what those threats might look like in action, identifying points of vulnerability in the social and technical systems on which you depend, and considering how those threats might be mitigated or resolved \citep{torr_demystifying_2005}. Being explicit about threat models helps you prioritize, build consensus with colleagues, and check whether you have forgotten something important. As with all disasters, making those plans before you need them helps reduce the odds of them being needed, as planning may help you identify risks you can eliminate.
 
 \begin{enumerate}
 \item


### PR DESCRIPTION
From @kayleachampion

The current text (line 26-30) suggests considering one's threat model but does not describe what a threat model is or how to produce one. I don't suggest being exhaustive but a touch more context might help the (likely stressed) audience for the work.

Suggested revision:

When making plans, it's useful to know what you're planning \emph{for}. Building a \textbf{threat model} means taking a structured approach to identifying sources of threats, considering what those threats might look like in action, identifying points of vulnerability in the social and technical systems on which you depend, and considering how those threats might be mitigated or resolved \citep{torr_demystifying_2005}. Being explicit about threat models helps you prioritize, build consensus with colleagues, and check whether you have forgotten something important. As with all disasters, making those plans before you need them helps reduce the odds of them being needed, as planning may help you identify risks you can eliminate.

For the ref, maybe you have other ideas, my suggestion is:

https://github.com/Article{torr_demystifying_2005,
author={Torr, P.},
journal={IEEE Security & Privacy},
title={Demystifying the threat modeling process},
year={2005},
volume={3},
number={5},
pages={66-70},
doi={10.1109/MSP.2005.119}}