### PR TITLE
proposal: make "stay within the law" the first tip

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -159,18 +159,15 @@ as planning may help you identify risks you can eliminate.
 
 \end{enumerate}
 
-\section*{Tip 2: Stay within the law}
+\section*{Tip 2: Know and stay within the law}
 
-Ensuring your work remains usable is not worth putting yourself at legal risk.
-Before following any of the tips below,
-make sure you have a legal right to do so.
-Most institutions and journals now have policies for licensing code and/or releasing it publicly \cite{Katz2018,Ham2019}.
-Funding agencies at various levels also often have policies
+"Ensuring your work remains usable is not worth putting yourself at legal risk. Before following any of the tips below, make sure you have a legal right to do so. You will need to understand the legal status of the code you have developed before you can take further action. Grant-funded work often includes contractual clauses about ownership and dissemination of code produced as a consequence of grant funding; work done as a regular employee is often considered property of the employer; work done as a contractor depends on your contract. Most institutions and journals now have policies for licensing code and/or releasing it publicly \cite{Katz2018,Ham2019}. Funding agencies at various levels also often have policies
 (e.g.,
 EU\footnote{\url{https://commission.europa.eu/about/departments-and-executive-agencies/digital-services/open-source-software-strategy_en}}
 and NASA\footnote{\url{https://science.nasa.gov/open-science/nasa-open-science-funding-opportunities}})
 which may or may not align with those of institutions and journals,
-and institutional policies may place restrictions on what you are allowed to say publicly about your situation.
+and institutional policies as well as the text of any severance package or work stoppage agreement may place restrictions on what you are allowed to say publicly about your situation."
+
 Our first actionable tip is therefore to find out what those policies are,
 e.g.,
 whether you need explicitly permission to publish your software,


### PR DESCRIPTION
Issue converted to PR as requested - issue and edit @kayleachampion 

Comment from Kris (Flatlandian) - having Tip2 as the '1st' actionable tip is a bit odd.

Tip 2 (lines 60-91 in the present document) is 'Stay within the law'. I suggest that this is probably "Know and stay within the law and your contract", and that 'Know and stay within the law and your contract' might be justifiably re-positioned to be Tip 1 as it colors and flavors everything which comes after it; the tip even describes itself as the first tip (line 67).

Suggested edits:

"Ensuring your work remains usable is not worth putting yourself at legal risk. Before following any of the tips below, make sure you have a legal right to do so. You will need to understand the legal status of the code you have developed before you can take further action. Grant-funded work often includes contractual clauses about ownership and dissemination of code produced as a consequence of grant funding; work done as a regular employee is often considered property of the employer; work done as a contractor depends on your contract. Most institutions and journals now have policies for licensing code and/or releasing it publicly \cite{Katz2018,Ham2019}. Funding agencies at various levels also often have policies (e.g.,
EU\footnote{\url{https://commission.europa.eu/about/departments-and-executive-agencies/digital-services/open-source-software-strategy_en}} and NASA\footnote{\url{https://science.nasa.gov/open-science/nasa-open-science-funding-opportunities}}) which may or may not align with those of institutions and journals, and institutional policies as well as the text of any severance package or work stoppage agreement may place restrictions on what you are allowed to say publicly about your situation."