### PR TITLE
fix: minor edits and rewording

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -218,17 +218,17 @@ and make sure that your right to share your work is written into your contract.
 Making your code comply with policy after the fact is riskier and more time-consuming than doing so early,
 and sometimes not possible.
 
-\section*{Tip 3: Decide if you are ending, pausing, and passing on}
+\section*{Tip 3: Decide if you are ending, pausing, or handing off}
 
 There are thousands of books in print about how to start a business,
 but only a handful describe how to hand one over or wind one down,
 and most of those focus on succession within family-owned businesses.
-Guides to running a laboratory such as \cite{Barker2010,Cohen2018} say little more,
-so such wisdom as we have is passed on person-to-person if it is passed on at all.
+Guides to running a laboratory, e.g.,~\cite{Barker2010,Cohen2018} say little more,
+so such wisdom as we have is generally passed on person-to-person if it is passed on at all.
 
 The first step is to decide if work on the project is ending,
 being suspended temporarily (for some version of ``temporarily''),
-or if you are handing it on to someone else.
+or if you are handing it off to someone else.
 If the project is ending or going on hiatus,
 focus on making what you have accomplished findable and citable
 as discussed in the tips that follow.
@@ -239,11 +239,11 @@ Doing this may actually help you realize that the project doesn't have to end,
 but can instead be folded into someone else's work,
 even if you are no longer involved.
 
-If instead you hope to hand the project on to someone else,
+If instead you hope to hand the project off to someone else,
 you can either choose a successor
 (who will typically be someone already working on the project)
 or ask your peers for volunteers or recommendations.
-Writing a \emph{succession plan} that describes what the work will actually entail
+Writing a \emph{succession plan} that describes what the work of becoming, and then being, the maintainer will actually entail, 
 will help in both cases.
 What will your successor have to learn and do during the transition?
 What will they be responsible for once they are in charge?


### PR DESCRIPTION
changes raised in issue 22 by  @kayleachampion plus some edits (more commas and an extra word or two) by me.

The title of tip 3 might be better phrased as: "Decide if you are ending, pausing, or handing off" -- the original has an 'and' constructor, suggesting all three be done at once. I would say "handing off" is more apt than "passing on", since passing on also means dying (!!)

Line 96 -- "such as [8,9]" --> "[e.g., 8, 9]"

Line 99 -- "handing it on to someone" --> "handing it off to someone"

Line 106 -- "to hand the project on" --> "to hand the project off"

Line 109 -- "the work will actually entail" --> "the work of becoming and then being the maintainer will actually entail"

(ref to Tip 2 in line 127 will need to change to Tip 1 if Issue https://github.com/RichardLitt/Quick-tips-for-making-your-software-outlive-your-job/issues/20 is accepted)