### PR TITLE
proposal: include a back pointer to the threat modeling section

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -97,7 +97,7 @@ by initiatives like \href{https://sfdora.org/}{DORA},
 \href{https://coara.eu/}{coARA},
 and \href{https://adore.software/}{ADORE.software}.
 
-\section*{Tip 1: Consider your threat model}
+\section*{Tip 1: Consider your threat model}\label{threats}
 
 When making plans, it's useful to know what you're planning \emph{for}.
 Being explicit about \textbf{threat models} helps you prioritize,
@@ -331,7 +331,7 @@ as this is where people and automated tools alike will look for it.
 
 Now that you're legally able to share your code, remember LOCKSS: Lots of Copies Keep Stuff Safe.
 But copies are not enough:
-the threats to your project are political as well as technological,
+the threats to your project are political as well as technological~\ref{threats},
 so you should ensure that loss of institutional support
 (or worse, that institution turning on you)
 does not mean loss of access.
@@ -425,7 +425,7 @@ if you distribute your code as a package on \href{https://pypi.org/}{PyPI},
 \href{https://anaconda.org/anaconda/conda}{Conda},
 or \href{https://cran.r-project.org/}{CRAN},
 that package can contain all of the source code.
-Doing this also fosters community collaboration
+Doing this also fosters community collaboration.
 
 \section*{Tip 6: Encourage community adoption}
 


### PR DESCRIPTION
I added a ref-link as suggested by 

@kayleachampion

from issue #24 

Line 158 -159 ("the threats to your project are political as well as technological") could include a pointer back to the threat modeling tip (whatever tip number it winds up as). Much of what's said in this tip is tied to threat modeling. Line 207 "also fosters community collaboration " -- missing '.' at the end of the sentence.