### PR TITLE
proposal: remove commentary on Mastodon / Bluesky / Twitter

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -618,10 +618,7 @@ Make that work meaningful by helping others.
 Tell your colleagues what you have learned about your institution's legal requirements,
 about navigating its bureaucracy,
 and about the least hurtful way to break the news to your students, collaborators, and users.
-Share your own tips on social media
-(preferably Mastodon rather than X or Bluesky,
-as the latter two are single points of institutional failure),
-and share things that \emph{haven't} worked as well
+Share your own tips on social media and share things that \emph{haven't} worked as well,
 so that other people can avoid stepping on the same landmines.
 
 Most importantly,


### PR DESCRIPTION
"(preferably Mastodon rather than X or Bluesky, as the latter two are single points of institutional failure)"

I think this ought be removed.  I don't think it is needed, it could slide into politics, and Mastodon and Bluesky, it's not so clear cut.