### PR TITLE
Add submission to Software Heritage Archive to Tip 8

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -606,6 +606,12 @@ A few others include:
   If the funding changed then say that the work is unfunded.
   This information is often the most useful for users but the hardest to find.
   Saying it up front will help others understand how your work is positioned.
+  
+  \item
+  Following on from Tip 5, you can \href{https://archive.softwareheritage.org/browse/search/}{search the Software Heritage Archive}
+  with your repository url to check whether it has been saved.
+  If your repository is not found in the archive,
+  there is a \href{https://archive.softwareheritage.org/save/}{simple process} to submit it for preservation.
 
 \end{enumerate}
 

--- a/contributors.tex
+++ b/contributors.tex
@@ -27,6 +27,7 @@ Phani Velicheti\textsuperscript{29},
 Daniel Morillo-Cuadrado\textsuperscript{30},
 Tommy Guy\textsuperscript{31},
 Jan Ainali\textsuperscript{32}
+Pierre Marshall\textsuperscript{33}
 \\
 \bigskip
 \textbf{2} CURIOSS, Lero, University of Galway, Ireland, \orcid{0009-0008-6205-0296}\\
@@ -58,5 +59,6 @@ Jan Ainali\textsuperscript{32}
 \textbf{30} Universidad Nacional de Educación a Distancia (UNED), Spain, \orcid{0000-0003-3021-3878}\\
 \textbf{31} \orcid{0009-0003-3652-5036}\\
 \textbf{32} \orcid{0000-0001-8747-1670}
+\textbf{33} \orcid{0000-0001-9245-7670}
 
 * richard@burntfen.com


### PR DESCRIPTION
The Software Heritage Archive is already mentioned in Tip 5, but could also come under Tip 8 as a quick and easy thing you can do to preserve a repository. The submission process takes about 20 seconds.