### PR TITLE
Update code-rules.tex

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -205,13 +205,13 @@ and how they might be mitigated or resolved \cite{Torr2005}.
 Being explicit about threat models helps you prioritize,
 build consensus with colleagues,
 and check whether you have forgotten something important.
-As with all disasters,
-making those plans before you need them may help you identify risks you can eliminate.
+As with all disaster planning,
+making plans before you need them may help you identify risks you can eliminate proactively.
 
 \begin{enumerate}
 \item
   \textbf{Individual threats} affect one or a few members of your team,
-  such as a foreign student having their visa revoked without notice
+  such as a student having their visa revoked without notice
   or a contributor taking extended leave.
   Especially for software under the maintenance of a single author,
   individual threats can also come from more mundane career or life changes.


### PR DESCRIPTION
refining language in tip 2 to make antecedent clear; I think we can omit 'foreign' when talking about visas being pulled.