### PR TITLE
Update code-rules.tex

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -354,7 +354,7 @@ as this is where people and automated tools alike will look for it.
 
 \begin{quote}
   \noindent
-  \textbf{The Law, Again}
+  \textbf{The law, again}
 
   Most discussion of open source licensing focuses on circumstances in a handful of affluent countries
   in the same way as discussion of fiscal sponsorship (Tip~3).
@@ -378,7 +378,7 @@ does not mean loss of access.
 
 \begin{quote}
   \noindent
-  \textbf{The Road Not Taken}
+  \textbf{The road not taken}
 
   \cite{Langille2010} described a file-sharing system for scientific data
   based on the BitTorrent protocol.
@@ -422,7 +422,7 @@ even when your contact address changes.
 
 \begin{quote}
   \noindent
-  \textbf{What's In a Project?}
+  \textbf{What's in a project?}
 
   When deciding what to store where,
   remember that your version control repository only stores part of what makes up your project.
@@ -443,7 +443,7 @@ you can also snapshot the current state of repositories in a compressed archive 
 (e.g., \texttt{.zip} or \texttt{.tar.gz})
 and deposit those copies with the \href{https://osf.io/}{Open Science Foundation} (OSF),
 \href{https://zenodo.org/}{Zenodo},
-or \href{https://figshare.com/}{figshare}.
+or \href{https://figshare.com/}{Figshare}.
 (Zenodo even integrates with GitHub so that tagging a release on GitHub
 automatically triggers deposit of a new archive on Zenodo,
 but again,
@@ -512,7 +512,7 @@ and is the best way to ensure that you land well after you leave your current po
 
 \begin{quote}
   \noindent
-  \textbf{One to Many}
+  \textbf{One to many}
 
   If you can, have at least one person outside your organization commit to your code.
   Such community contributions lead to joint ownership of intellectual property (IP),


### PR DESCRIPTION
harmonize capitalization pattern across parts; tips aren't using title case so so it seems likely the subparts of tips are even less likely to want capitalization