### PR TITLE
footnote links: suggest refs to archive.org with archival date (these resources are likely to disappear!)

### DIFF
--- a/code-rules.tex
+++ b/code-rules.tex
@@ -1,6 +1,5 @@
 \documentclass[10pt,letterpaper]{article}
 \input{plos-settings}
-\hypersetup{colorlinks=true,allcolors=blue}
 
 \begin{document}
 \vspace*{0.2in}

--- a/code-rules.tex
+++ b/code-rules.tex
@@ -1,5 +1,6 @@
 \documentclass[10pt,letterpaper]{article}
 \input{plos-settings}
+\hypersetup{colorlinks=true,allcolors=blue}
 
 \begin{document}
 \vspace*{0.2in}
@@ -131,9 +132,9 @@ make sure you have a legal right to do so.
 Most institutions and journals now have policies for licensing code and/or releasing it publicly \cite{Katz2018,Ham2019}.
 Funding agencies at various levels also often have policies
 (e.g.,
-EU\footnote{\url{https://commission.europa.eu/about/departments-and-executive-agencies/digital-services/open-source-software-strategy_en}},
-UKRI\footnote{\url{https://www.ukri.org/manage-your-award/publishing-your-research-findings/making-your-research-data-open/}},
-and NASA\footnote{\url{https://science.nasa.gov/open-science/nasa-open-science-funding-opportunities}})
+EU\footnote{\url{https://web.archive.org/web/20250424181252/https://commission.europa.eu/about/departments-and-executive-agencies/digital-services/open-source-software-strategy_en} (archived on Apr 24 2025)},
+UKRI\footnote{\url{https://web.archive.org/web/20250422025105/https://www.ukri.org/manage-your-award/publishing-your-research-findings/making-your-research-data-open/} (archived on Apr 22 2025)},
+and NASA\footnote{\url{https://web.archive.org/web/20250422005753/https://science.nasa.gov/open-science/nasa-open-science-funding-opportunities/} (archived on Apr 22 2025)})
 which may or may not align with those of institutions and journals,
 and institutional policies may place restrictions on what you are allowed to say publicly about your situation.
 Our first actionable tip is therefore to find out what those policies are,
@@ -304,7 +305,7 @@ Some projects try to ensure longevity by working with a fiscal sponsor such as
 \href{https://sfconservancy.org/}{Software Freedom Conservancy},
 \href{https://www.eclipse.org/}{the Eclipse Foundation},
 \href{https://oscollective.org/}{Open Source Collective},
-or other \href{https://sustainoss.org/academic-map/organizations/index.html}{foundations and fiscal hosts}.
+or other \href{https://sustainoss.org/academic-map/organizations/}{foundations and fiscal hosts}.
 Through fiscal hosting,
 a project can take donations from its community to fund continued maintenance and other costs.
 Universities and governments are generally poorly suited for this due to high overheads and procurement costs;
@@ -398,7 +399,7 @@ does not mean loss of access.
 \end{quote}
 
 \href{https://github.com/}{GitHub},
-\href{https://gitlab.com}{GitLab},
+\href{https://gitlab.com/}{GitLab},
 and \href{https://bitbucket.org/}{BitBucket}
 are social coding platforms centered around Git,
 a widely-used open source version control tool.


### PR DESCRIPTION
 + set hyperref to color links + link cleanups

There are other links in the paper (e.g., blog links) that are also perhaps worth referring to via archive.org?